### PR TITLE
chore: add dockerized backend infrastructure

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,4 @@
+NODE_ENV=development
+PORT=3000
+DATABASE_URL=postgresql://app:app@db:5432/app
+CORS_ORIGIN=http://localhost:5173

--- a/apps/api/.env.local
+++ b/apps/api/.env.local
@@ -1,0 +1,4 @@
+NODE_ENV=development
+PORT=3000
+DATABASE_URL=postgresql://app:app@db:5432/app
+CORS_ORIGIN=http://localhost:5173

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "echo 'start api dev server'",
+    "dev": "node -e \"require('http').createServer((_,res)=>{res.end('API dev stub')}).listen(3000)\"",
     "build": "echo 'build api'",
     "start": "echo 'start api'"
   },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3.9"
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: app
+      POSTGRES_DB: app
+    ports: ["5432:5432"]
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U app"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  api:
+    build:
+      context: ./apps/api
+      dockerfile: ../../docker/api.Dockerfile
+    env_file: ./apps/api/.env.local
+    depends_on:
+      db:
+        condition: service_healthy
+    ports: ["3000:3000"]
+    command: ["npm","run","dev"]
+    volumes:
+      - ./apps/api:/app
+
+  adminer:
+    image: adminer
+    restart: always
+    ports: ["8080:8080"]
+
+volumes:
+  db_data:

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json* .npmrc* ./
+RUN npm ci || npm install
+COPY . .
+EXPOSE 3000
+CMD ["npm","run","dev"]


### PR DESCRIPTION
## Summary
- add docker-compose with Postgres, API stub, and Adminer services
- add Node API Dockerfile for dev container
- add env templates and stub dev script for API

## Testing
- `docker compose up --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a758a5cfb8832395fc380270f68a99