### PR TITLE
feat(api): add typed env config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+node_modules/
+dist/
+npm-debug.log*
+pnpm-debug.log*
+yarn-*.log
+.env
+.env.local
+apps/*/.env
+apps/*/.env.local
+.DS_Store
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -24,3 +24,16 @@ pnpm install
 - Set up the backend with NestJS and Prisma in `apps/api`.
 - Add Docker and Docker Compose configuration in `docker/`.
 - Implement the frontend in `apps/web/`.
+
+## Environment Setup
+
+Copy env template:
+
+```bash
+cp apps/api/.env.example apps/api/.env.local
+```
+
+Edit secrets before running in shared env.
+
+API uses typed loader in `apps/api/src/config/env.ts` to validate env vars.
+

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,4 +1,12 @@
 NODE_ENV=development
 PORT=3000
-DATABASE_URL=postgresql://app:app@db:5432/app
 CORS_ORIGIN=http://localhost:5173
+
+DATABASE_URL=postgresql://app:app@db:5432/app
+SESSION_SECRET=change_me_dev_only
+COOKIE_SECURE=false
+CSRF_ENABLED=true
+JWT_SECRET=change_me_dev_only
+JWT_EXPIRES_IN=2h
+APP_LOCALE=pt-BR
+APP_TIMEZONE=America/Sao_Paulo

--- a/apps/api/.env.local
+++ b/apps/api/.env.local
@@ -1,4 +1,0 @@
-NODE_ENV=development
-PORT=3000
-DATABASE_URL=postgresql://app:app@db:5432/app
-CORS_ORIGIN=http://localhost:5173

--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -7,7 +7,13 @@
     "": {
       "name": "@codex/api",
       "version": "0.1.0",
-      "devDependencies": {},
+      "dependencies": {
+        "dotenv": "^16.4.5",
+        "zod": "^3.23.8"
+      },
+      "devDependencies": {
+        "tsx": "^4.16.0"
+      },
       "engines": {
         "node": ">=18"
       }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -3,12 +3,17 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "node -e \"require('http').createServer((_,res)=>{res.end('API dev stub')}).listen(3000)\"",
+    "dev": "tsx watch src/index.ts",
     "build": "echo 'build api'",
     "start": "echo 'start api'"
   },
-  "dependencies": {},
-  "devDependencies": {},
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "tsx": "^4.16.0"
+  },
   "engines": {
     "node": ">=18"
   }

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -1,0 +1,24 @@
+import 'dotenv/config'
+import { z } from 'zod'
+
+const Schema = z.object({
+  NODE_ENV: z.enum(['development','test','production']).default('development'),
+  PORT: z.coerce.number().positive().default(3000),
+  CORS_ORIGIN: z.string().default('http://localhost:5173'),
+  DATABASE_URL: z.string().url(),
+  SESSION_SECRET: z.string().min(10).default('change_me_dev_only'),
+  COOKIE_SECURE: z.coerce.boolean().default(false),
+  CSRF_ENABLED: z.coerce.boolean().default(true),
+  JWT_SECRET: z.string().min(10).default('change_me_dev_only'),
+  JWT_EXPIRES_IN: z.string().default('2h'),
+  APP_LOCALE: z.string().default('pt-BR'),
+  APP_TIMEZONE: z.string().default('America/Sao_Paulo'),
+})
+
+const parsed = Schema.safeParse(process.env)
+if (!parsed.success) {
+  console.error('Invalid env config:', parsed.error.flatten().fieldErrors)
+  process.exit(1)
+}
+
+export const config = parsed.data

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,0 +1,11 @@
+import http from 'http'
+import { config } from './config/env'
+
+const server = http.createServer((_, res) => {
+  res.writeHead(200, { 'Content-Type': 'application/json' })
+  res.end(JSON.stringify({ status: 'ok', port: config.PORT }))
+})
+
+server.listen(config.PORT, () => {
+  console.log(`[api] running on :${config.PORT} (${config.NODE_ENV})`)
+})


### PR DESCRIPTION
## Summary
- ignore env files and editor artifacts in root `.gitignore`
- add typed environment loader using zod for API
- document environment setup workflow

## Testing
- `npm install --registry=https://registry.npmjs.org` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dotenv)*
- `npm run dev` *(fails: tsx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a75b65314483238fc0d54af15312e9