### PR TITLE
chore(api): add linting and formatting setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+coverage
+build
+.config.js
+.config.cjs
+apps//dist
+apps//coverage

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+coverage
+build
+.tmp
+.log
+apps//dist
+apps/*/coverage

--- a/README.md
+++ b/README.md
@@ -37,3 +37,14 @@ Edit secrets before running in shared env.
 
 API uses typed loader in `apps/api/src/config/env.ts` to validate env vars.
 
+
+## Code Quality
+
+Run lint: (cd apps/api && npm run lint)
+
+Fix lint issues: (cd apps/api && npm run lint:fix)
+
+Check formatting: (cd apps/api && npm run format:check)
+
+Apply formatting: (cd apps/api && npm run format)
+

--- a/apps/api/.eslintignore
+++ b/apps/api/.eslintignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+coverage
+build
+*.config.js
+*.config.cjs

--- a/apps/api/.eslintrc.cjs
+++ b/apps/api/.eslintrc.cjs
@@ -1,0 +1,41 @@
+module.exports = {
+  root: true,
+  env: { node: true, es2022: true },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: false,
+    sourceType: 'module',
+    ecmaVersion: 'latest',
+  },
+  plugins: ['@typescript-eslint', 'import', 'unused-imports'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:import/recommended',
+    'plugin:import/typescript',
+    'plugin:prettier/recommended',
+  ],
+  settings: {
+    'import/resolver': {
+      typescript: true,
+      node: true,
+    },
+  },
+  rules: {
+    'prettier/prettier': 'warn',
+    'no-console': 'off',
+    'import/order': [
+      'warn',
+      {
+        alphabetize: { order: 'asc', caseInsensitive: true },
+        'newlines-between': 'always',
+        groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index', 'object'],
+      },
+    ],
+    'unused-imports/no-unused-imports': 'warn',
+    '@typescript-eslint/no-unused-vars': [
+      'warn',
+      { argsIgnorePattern: '^', varsIgnorePattern: '^' },
+    ],
+  },
+};

--- a/apps/api/.prettierrc.json
+++ b/apps/api/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,13 +5,26 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "echo 'build api'",
-    "start": "echo 'start api'"
+    "start": "echo 'start api'",
+    "lint": "eslint \"src/**/*.{ts,tsx}\" --max-warnings=0",
+    "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "dotenv": "^16.4.5",
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
+    "@typescript-eslint/parser": "^7.18.0",
+    "eslint": "^9.8.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-prettier": "^5.1.3",
+    "eslint-plugin-unused-imports": "^3.2.0",
+    "prettier": "^3.3.3",
     "tsx": "^4.16.0"
   },
   "engines": {

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -1,8 +1,8 @@
-import 'dotenv/config'
-import { z } from 'zod'
+import 'dotenv/config';
+import { z } from 'zod';
 
 const Schema = z.object({
-  NODE_ENV: z.enum(['development','test','production']).default('development'),
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
   PORT: z.coerce.number().positive().default(3000),
   CORS_ORIGIN: z.string().default('http://localhost:5173'),
   DATABASE_URL: z.string().url(),
@@ -13,12 +13,12 @@ const Schema = z.object({
   JWT_EXPIRES_IN: z.string().default('2h'),
   APP_LOCALE: z.string().default('pt-BR'),
   APP_TIMEZONE: z.string().default('America/Sao_Paulo'),
-})
+});
 
-const parsed = Schema.safeParse(process.env)
+const parsed = Schema.safeParse(process.env);
 if (!parsed.success) {
-  console.error('Invalid env config:', parsed.error.flatten().fieldErrors)
-  process.exit(1)
+  console.error('Invalid env config:', parsed.error.flatten().fieldErrors);
+  process.exit(1);
 }
 
-export const config = parsed.data
+export const config = parsed.data;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,11 +1,11 @@
-import http from 'http'
-import { config } from './config/env'
+import http from 'http';
+import { config } from './config/env';
 
 const server = http.createServer((_, res) => {
-  res.writeHead(200, { 'Content-Type': 'application/json' })
-  res.end(JSON.stringify({ status: 'ok', port: config.PORT }))
-})
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ status: 'ok', port: config.PORT }));
+});
 
 server.listen(config.PORT, () => {
-  console.log(`[api] running on :${config.PORT} (${config.NODE_ENV})`)
-})
+  console.log(`[api] running on :${config.PORT} (${config.NODE_ENV})`);
+});

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add repo-wide editorconfig, lint & format ignores
- configure ESLint and Prettier for `apps/api`
- document lint and format scripts

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/eslint-plugin')*
- `npm run format:check`

------
https://chatgpt.com/codex/tasks/task_e_68a75cf3badc8323b43f7745966f5f9d