### PR TITLE
feat(api): add Prisma and PostgreSQL integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,29 @@ Edit secrets before running in shared env.
 API uses typed loader in `apps/api/src/config/env.ts` to validate env vars.
 
 
+## Database Setup
+
+Ensure Docker PostgreSQL service is running.
+
+Copy env template and set the database URL:
+
+```bash
+cp apps/api/.env.example apps/api/.env.local
+```
+
+Run migrations:
+
+```bash
+cd apps/api
+npm run prisma:migrate
+```
+
+Open Prisma Studio for inspection:
+
+```bash
+npm run prisma:studio
+```
+
 ## Code Quality
 
 Run lint: (cd apps/api && npm run lint)

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,8 +1,8 @@
+# Environment variables for the API
 NODE_ENV=development
 PORT=3000
 CORS_ORIGIN=http://localhost:5173
-
-DATABASE_URL=postgresql://app:app@db:5432/app
+DATABASE_URL=postgresql://app:app@localhost:5432/app
 SESSION_SECRET=change_me_dev_only
 COOKIE_SECURE=false
 CSRF_ENABLED=true
@@ -10,3 +10,4 @@ JWT_SECRET=change_me_dev_only
 JWT_EXPIRES_IN=2h
 APP_LOCALE=pt-BR
 APP_TIMEZONE=America/Sao_Paulo
+

--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -9,10 +9,21 @@
       "version": "0.1.0",
       "dependencies": {
         "dotenv": "^16.4.5",
-        "zod": "^3.23.8"
+        "zod": "^3.23.8",
+        "@prisma/client": "^5.16.1"
       },
       "devDependencies": {
-        "tsx": "^4.16.0"
+        "tsx": "^4.16.0",
+        "prisma": "^5.16.1",
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
+        "eslint": "^9.8.0",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-import-resolver-typescript": "^3.6.1",
+        "eslint-plugin-import": "^2.29.1",
+        "eslint-plugin-prettier": "^5.1.3",
+        "eslint-plugin-unused-imports": "^3.2.0",
+        "prettier": "^3.3.3"
       },
       "engines": {
         "node": ">=18"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,13 +9,19 @@
     "lint": "eslint \"src/**/*.{ts,tsx}\" --max-warnings=0",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "prisma:generate": "prisma generate --schema=prisma/schema.prisma",
+    "prisma:migrate": "prisma migrate dev --name init --schema=prisma/schema.prisma",
+    "prisma:studio": "prisma studio --schema=prisma/schema.prisma",
+    "prisma:seed": "tsx prisma/seed.ts"
   },
   "dependencies": {
     "dotenv": "^16.4.5",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "@prisma/client": "^5.16.1"
   },
   "devDependencies": {
+    "prisma": "^5.16.1",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "eslint": "^9.8.0",

--- a/apps/api/prisma/migrations/20240821180654_init/migration.sql
+++ b/apps/api/prisma/migrations/20240821180654_init/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "User_email_key" UNIQUE ("email")
+);
+
+-- CreateTable
+CREATE TABLE "Transaction" (
+    "id" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "value" DECIMAL(65,30) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "Transaction_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "Transaction_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+

--- a/apps/api/prisma/migrations/migration_lock.toml
+++ b/apps/api/prisma/migrations/migration_lock.toml
@@ -1,0 +1,4 @@
+# Prisma Migrate lockfile
+
+provider = "postgresql"
+

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1,0 +1,29 @@
+generator client {
+  provider = "prisma-client-js"
+  output   = "../node_modules/@prisma/client"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id           String        @id @default(uuid())
+  email        String        @unique
+  password     String
+  createdAt    DateTime      @default(now())
+  updatedAt    DateTime      @updatedAt
+  transactions Transaction[]
+}
+
+model Transaction {
+  id        String   @id @default(uuid())
+  type      String   // "income" or "outcome"
+  name      String
+  value     Decimal
+  createdAt DateTime @default(now())
+  userId    String
+  user      User     @relation(fields: [userId], references: [id])
+}
+

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -1,0 +1,28 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  await prisma.user.create({
+    data: {
+      email: 'user@example.com',
+      password: 'password',
+      transactions: {
+        create: [
+          { type: 'income', name: 'Salary', value: 1000 },
+          { type: 'outcome', name: 'Rent', value: 500 },
+        ],
+      },
+    },
+  });
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });
+

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,16 @@
 import http from 'http';
 import { config } from './config/env';
+import { prisma } from './lib/prisma';
+
+;(async () => {
+  try {
+    await prisma.$connect();
+    console.log('[api] Database connected');
+  } catch (err) {
+    console.error('[api] Database connection failed', err);
+    process.exit(1);
+  }
+})();
 
 const server = http.createServer((_, res) => {
   res.writeHead(200, { 'Content-Type': 'application/json' });

--- a/apps/api/src/lib/prisma.ts
+++ b/apps/api/src/lib/prisma.ts
@@ -1,0 +1,4 @@
+import { PrismaClient } from '@prisma/client';
+
+export const prisma = new PrismaClient();
+


### PR DESCRIPTION
## Summary
- add Prisma schema and client setup for User and Transaction
- wire API to PostgreSQL via Prisma and provide migration/seed scripts
- document database setup workflow for developers

## Testing
- `npm run prisma:generate` *(fails: prisma not found)*
- `npm run prisma:migrate` *(fails: prisma not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a75fd15c04832381d0aa92c30871c9