### PR TITLE
feat(api): add jwt auth routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Edit secrets before running in shared env.
 
 API uses typed loader in `apps/api/src/config/env.ts` to validate env vars.
 
+## Authentication
+
+The API exposes basic authentication endpoints.
+
+- **Register**: `POST /auth/register` with `{ email, password }` creates a new user.
+- **Login**: `POST /auth/login` with `{ email, password }` returns a signed JWT.
+- **Me**: `GET /auth/me` with header `Authorization: Bearer <token>` returns the current user.
 
 ## Code Quality
 

--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -8,18 +8,10 @@
       "name": "@codex/api",
       "version": "0.1.0",
       "dependencies": {
-        "@prisma/client": "^5.17.0",
-        "bcryptjs": "^2.4.3",
-        "body-parser": "^1.20.2",
-        "cors": "^2.8.5",
         "dotenv": "^16.4.5",
-        "express": "^4.19.2",
-        "express-session": "^1.17.3",
-        "jsonwebtoken": "^9.0.2",
         "zod": "^3.23.8"
       },
       "devDependencies": {
-        "prisma": "^5.17.0",
         "tsx": "^4.16.0"
       },
       "engines": {

--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -8,10 +8,18 @@
       "name": "@codex/api",
       "version": "0.1.0",
       "dependencies": {
+        "@prisma/client": "^5.17.0",
+        "bcryptjs": "^2.4.3",
+        "body-parser": "^1.20.2",
+        "cors": "^2.8.5",
         "dotenv": "^16.4.5",
+        "express": "^4.19.2",
+        "express-session": "^1.17.3",
+        "jsonwebtoken": "^9.0.2",
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "prisma": "^5.17.0",
         "tsx": "^4.16.0"
       },
       "engines": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,8 +12,15 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "body-parser": "^1.20.2",
+    "cors": "^2.8.5",
     "dotenv": "^16.4.5",
-    "zod": "^3.23.8"
+    "express": "^4.19.2",
+    "express-session": "^1.17.3",
+    "jsonwebtoken": "^9.0.2",
+    "zod": "^3.23.8",
+    "@prisma/client": "^5.17.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.18.0",
@@ -25,6 +32,7 @@
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-unused-imports": "^3.2.0",
     "prettier": "^3.3.3",
+    "prisma": "^5.17.0",
     "tsx": "^4.16.0"
   },
   "engines": {

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1,0 +1,17 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  password  String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,11 +1,30 @@
-import http from 'http';
-import { config } from './config/env';
+import bodyParser from 'body-parser';
+import cors from 'cors';
+import express from 'express';
+import session from 'express-session';
 
-const server = http.createServer((_, res) => {
-  res.writeHead(200, { 'Content-Type': 'application/json' });
-  res.end(JSON.stringify({ status: 'ok', port: config.PORT }));
+import { config } from './config/env';
+import authRoutes from './routes/auth';
+
+const app = express();
+
+app.use(cors({ origin: config.CORS_ORIGIN, credentials: true }));
+app.use(bodyParser.json());
+app.use(
+  session({
+    secret: config.SESSION_SECRET,
+    resave: false,
+    saveUninitialized: false,
+    cookie: { secure: config.COOKIE_SECURE },
+  }),
+);
+
+app.use('/auth', authRoutes);
+
+app.get('/', (_, res) => {
+  res.json({ status: 'ok', port: config.PORT });
 });
 
-server.listen(config.PORT, () => {
+app.listen(config.PORT, () => {
   console.log(`[api] running on :${config.PORT} (${config.NODE_ENV})`);
 });

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,0 +1,30 @@
+import { NextFunction, Request, Response } from 'express';
+import jwt from 'jsonwebtoken';
+
+import { config } from '../config/env';
+
+export interface AuthRequest extends Request {
+  user?: jwt.JwtPayload | string;
+}
+
+export default function auth(req: AuthRequest, res: Response, next: NextFunction): void {
+  const header = req.headers.authorization;
+  if (!header) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  const [scheme, token] = header.split(' ');
+  if (scheme !== 'Bearer' || !token) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  try {
+    const decoded = jwt.verify(token, config.JWT_SECRET);
+    req.user = decoded;
+    next();
+  } catch {
+    res.status(401).json({ error: 'Unauthorized' });
+  }
+}

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,0 +1,76 @@
+import { Router } from 'express';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import { PrismaClient } from '@prisma/client';
+
+import { config } from '../config/env';
+import auth, { AuthRequest } from '../middleware/auth';
+
+const router = Router();
+const prisma = new PrismaClient();
+
+router.post('/register', async (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) {
+    res.status(400).json({ error: 'Email and password required' });
+    return;
+  }
+
+  const hashed = await bcrypt.hash(password, 10);
+  try {
+    const user = await prisma.user.create({
+      data: { email, password: hashed },
+    });
+    res.json({ id: user.id, email: user.email });
+  } catch (err) {
+    res.status(400).json({ error: 'Registration failed' });
+  }
+});
+
+router.post('/login', async (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) {
+    res.status(400).json({ error: 'Email and password required' });
+    return;
+  }
+
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) {
+    res.status(401).json({ error: 'Invalid credentials' });
+    return;
+  }
+
+  const valid = await bcrypt.compare(password, user.password);
+  if (!valid) {
+    res.status(401).json({ error: 'Invalid credentials' });
+    return;
+  }
+
+  const token = jwt.sign({ id: user.id, email: user.email }, config.JWT_SECRET, {
+    expiresIn: config.JWT_EXPIRES_IN,
+  });
+
+  res.json({ token });
+});
+
+router.get('/me', auth, async (req: AuthRequest, res) => {
+  const payload = req.user as { id: number } | undefined;
+  if (!payload?.id) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: payload.id },
+    select: { id: true, email: true, createdAt: true, updatedAt: true },
+  });
+
+  if (!user) {
+    res.status(404).json({ error: 'User not found' });
+    return;
+  }
+
+  res.json(user);
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- implement express backend with session support
- add JWT authentication routes for register/login/me
- document auth usage in README

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68a7693a4144832384b48e252c6274c8